### PR TITLE
Update SSO Example - Version, README, Redirect

### DIFF
--- a/dotnet-sso-example/Controllers/HomeController.cs
+++ b/dotnet-sso-example/Controllers/HomeController.cs
@@ -61,7 +61,7 @@ namespace WorkOS.SSOExampleApp.Controllers
                     {
                         ClientId = Environment.GetEnvironmentVariable("WORKOS_CLIENT_ID"),
                         Organization = "YOUR_ORGANIZATION_ID",
-                        RedirectURI = "https://localhost:5001/Home/Callback/",
+                        RedirectURI = "https://localhost:5001/Home/Callback",
                     };
                     // Call GetAuthorizationURL and store the resulting URL in a `url` variable.
                     string url = ssoService.GetAuthorizationURL(options);
@@ -82,7 +82,7 @@ namespace WorkOS.SSOExampleApp.Controllers
             {
                 ClientId = Environment.GetEnvironmentVariable("WORKOS_CLIENT_ID"),
                 Provider = provider,
-                RedirectURI = "https://localhost:5001/Home/Callback/",
+                RedirectURI = "https://localhost:5001/Home/Callback",
             };
 
             // Call GetAuthorizationURL and store the resulting URL in a `url` variable.

--- a/dotnet-sso-example/README.md
+++ b/dotnet-sso-example/README.md
@@ -7,7 +7,7 @@ An example application demonstrating how SSO works with WorkOS and .NET.
 Clone this repository and install dependencies:
 
 ```sh
-git clone https://github.com/workos/dotnet-example-applications.git && cd dotnet-sso-example && dotnet build
+git clone https://github.com/workos/dotnet-example-applications.git && cd dotnet-example-applications/dotnet-sso-example && dotnet build
 ```
 
 ## Configure your environment

--- a/dotnet-sso-example/WorkOS_SSO_Example_App.csproj
+++ b/dotnet-sso-example/WorkOS_SSO_Example_App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR updates 3 things:
- Update SSO README instructions to include the parent directory (cloning doesn't automatically `cd` you into the repo's parent directory)
- Remove trailing `/`s in the redirect URIs, as these lead to a redirect error
- Update `TargetFramework` to 9.0, as 6.0 is deprecated (see [here](https://dotnet.microsoft.com/en-us/download/dotnet/6.0))

After making these changes and following the steps in the README, I am able to sign in via SSO + Google OAuth.